### PR TITLE
Changes in loading params, fixes, and search objective outcome chagnes

### DIFF
--- a/cusub_cortex/cusub_cortex_bringup/launch/cortex.launch
+++ b/cusub_cortex/cusub_cortex_bringup/launch/cortex.launch
@@ -2,6 +2,8 @@
   <arg name="sub" default="leviathan" />
   <group ns="$(arg sub)/cusub_cortex">
     <include file="$(find mapper)/launch/mapper.launch"/>
-    <include file="$(find state_machine)/launch/state_machine.launch"/>
+    <include file="$(find state_machine)/launch/state_machine.launch" >
+      <arg name="sub" value="$(arg sub)" />
+    </include>
   </group>
 </launch>

--- a/cusub_cortex/state_machine/config/mission_config.yaml
+++ b/cusub_cortex/state_machine/config/mission_config.yaml
@@ -5,9 +5,10 @@
 
 tasks:
  start_gate:
-  prior: [8,-1,-1.5]
+  prior: [4,0,-1.5]
   search_alg: simple
   dist_behind_gate: 1.0
+  replan_thresh: 1.0
   failed_repeat: true
   object_localizers:
     start_gate_pole: ['gate_pnp_color', 'gate_pnp_bb', 'gate_midpoint']
@@ -39,4 +40,4 @@ tasks:
     roulette: roulette_watershed
 
 mission_tasks: # Tasks To Do In Order
- - dropper
+ - start_gate

--- a/cusub_cortex/state_machine/launch/state_machine.launch
+++ b/cusub_cortex/state_machine/launch/state_machine.launch
@@ -1,12 +1,12 @@
 <launch>
 
     <arg name="config_filename" default="mission_config.yaml"/>
-
+    <arg name="sub" default="leviathan" />
     <!-- Include the mission config parameters -->
     <rosparam command="load" file="$(find state_machine)/config/$(arg config_filename)"/>
-    
+
     <node name="state_machine_node" pkg="state_machine" type="smach_top.py" output="screen">
-        <param name="robotname" value="leviathan"/>
+        <param name="robotname" value="$(arg sub)"/>
     </node>
 
 </launch>

--- a/cusub_cortex/state_machine/scripts/smach_top.py
+++ b/cusub_cortex/state_machine/scripts/smach_top.py
@@ -18,15 +18,10 @@ from tasks.visit_task import VisitTask
 from tasks.bangbang_dice_task import BangBangDiceTask
 from tasks.bangbang_roulette_task import BangBangRouletteTask
 from tasks.naive_visual_servo_objective import NaiveVisualServoTask
-from tasks.dropper_task import DropperTask
+# from tasks.dropper_task import DropperTask
 # from tasks.bangbang_roulette_task import BangBangRouletteTask
 
-def genPoseMsg(list_xyz):
-    pose = Pose()
-    pose.position.x = list_xyz[0]
-    pose.position.y = list_xyz[1]
-    pose.position.z = list_xyz[2]
-    return pose
+
 
 def loadStateMachines(task_list):
     """
@@ -45,24 +40,20 @@ def loadStateMachines(task_list):
             task = task[6:] # trim "visit_"
             visit = True
 
-        # load params common to all tasks
-        prior = genPoseMsg(rospy.get_param("tasks/" + task + "/prior"))
-        search_alg = rospy.get_param("tasks/" + task + "/search_alg")
-
         if visit == True:
-            task_sm = VisitTask(prior, search_alg)
+            task_sm = VisitTask(task)
         elif task == "start_gate":
             task_sm = StartGate()
         elif task == "dice":
             task_sm = Dice()
         elif task == "bangbang_dice":
-            task_sm = BangBangDiceTask(prior, search_alg)
+            task_sm = BangBangDiceTask()
         elif task == "bangbang_roulette":
-            task_sm = BangBangRouletteTask(prior, search_alg)
-        elif task == "dropper":
-            task_sm = DropperTask(prior, search_alg)
+            task_sm = BangBangRouletteTask()
+        # elif task == "dropper":
+            # task_sm = DropperTask(prior, search_alg)
         elif task == "naive_visual_servo_objective":
-            task_sm = NaiveVisualServoTask(prior)
+            task_sm = NaiveVisualServoTask()
         else:
             raise ValueError("Unrecognized task: {}".format(task))
 
@@ -81,9 +72,9 @@ def main():
     Loop through the statemachines in order and link them
     """
     rospy.init_node('smach_top')
-
+    
     # All Objectives depend on the waypoint server so let's wait for it to initalize here
-    wayClient = actionlib.SimpleActionClient('cusub_common/waypoint', waypointAction)
+    wayClient = actionlib.SimpleActionClient('/'+rospy.get_param('~robotname')+'/cusub_common/waypoint', waypointAction)
     rospy.loginfo("Waiting for waypoint server")
     wayClient.wait_for_server()
     rospy.loginfo("---connected to server")

--- a/cusub_cortex/state_machine/src/tasks/bangbang_dice_task.py
+++ b/cusub_cortex/state_machine/src/tasks/bangbang_dice_task.py
@@ -19,23 +19,18 @@ from darknet_ros_msgs.msg import BoundingBox, BoundingBoxes
 
 class BangBangDiceTask(Task):
 
+    name = "bangbang_dice"
     outcomes = ['task_success','task_aborted']
 
-    def __init__(self, prior, searchAlg):
+    def __init__(self):
 
         super(BangBangDiceTask, self).__init__(self.outcomes) # become a state machine first
-        self.initObjectives(prior, searchAlg)
+        self.initObjectives(self.getPrior(), rospy.get_param("tasks/" + self.name + "/search_alg"))
         self.linkObjectives()
 
     def initObjectives(self, prior, searchAlg):
         self.search = Search(searchAlg, prior)
         self.attack = Attack(prior)
-
-    def initMapperSubs(self):
-        """
-        Just going to the prior so no need to act on any pose estimates
-        """
-        pass
 
     def linkObjectives(self):
         with self:
@@ -112,7 +107,7 @@ class Attack(Objective):
         self.darknetSub = rospy.Subscriber('darknet_ros/bounding_boxes', BoundingBoxes, self.boxes_received, queue_size=1, buff_size=10000000)
 
         # Okay this is what we'll use, interesting what's the cv?
-        self.diceStatePub = rospy.Publisher('cusub_common/motor_controllers/cv/yaw/state', Float64, queue_size=1) 
+        self.diceStatePub = rospy.Publisher('cusub_common/motor_controllers/cv/yaw/state', Float64, queue_size=1)
         self.diceSetpointPub = rospy.Publisher('cusub_common/motor_controllers/cv/yaw/setpoint', Float64, queue_size=1)
 
         # Depth and drive control those, just hold them in place, huh cv again here?
@@ -120,7 +115,7 @@ class Attack(Objective):
         self.diceDepthSetpointPub = rospy.Publisher('cusub_common/motor_controllers/cv/depth/setpoint', Float64, queue_size=1)
         self.driveStateSub = rospy.Subscriber("cusub_common/motor_controllers/pid/drive/state", Float64, self.driveStateCallback)
         self.drivePub = rospy.Publisher('cusub_common/motor_controllers/pid/drive/setpoint', Float64, queue_size=1)
-        self.imuSub = rospy.Subscriber("cusub_common/imu", Imu, self.imuCallback)        
+        self.imuSub = rospy.Subscriber("cusub_common/imu", Imu, self.imuCallback)
 
         self.yawStateSub = rospy.Subscriber("cusub_common/motor_controllers/pid/yaw/state", Float64, self.yawStateCallback)
         self.depthStateSub = rospy.Subscriber("cusub_common/motor_controllers/pid/depth/state", Float64, self.depthStateCallback)

--- a/cusub_cortex/state_machine/src/tasks/bangbang_roulette_task.py
+++ b/cusub_cortex/state_machine/src/tasks/bangbang_roulette_task.py
@@ -21,12 +21,13 @@ from actuator.srv import ActivateActuator
 
 class BangBangRouletteTask(Task):
 
+    name = "bangbang_roulette"
     outcomes = ['task_success','task_aborted']
 
     def __init__(self, prior, searchAlg):
 
         super(BangBangRouletteTask, self).__init__(self.outcomes) # become a state machine first
-        self.initObjectives(prior, searchAlg)
+        self.initObjectives(self.getPrior(), rospy.get_param("tasks/" + self.name + "/search_alg"))
         self.linkObjectives()
 
     def initObjectives(self, prior, searchAlg):

--- a/cusub_cortex/state_machine/src/tasks/visit_task.py
+++ b/cusub_cortex/state_machine/src/tasks/visit_task.py
@@ -14,22 +14,15 @@ class VisitTask(Task):
 
     outcomes = ['task_success','task_aborted']
 
-    def __init__(self, prior, searchAlg):
-
+    def __init__(self, task_name):
+        self.name = task_name
         super(VisitTask, self).__init__(self.outcomes) # become a state machine first
-        self.initObjectives(prior, searchAlg)
+        self.initObjectives(self.getPrior(), rospy.get_param("tasks/" + self.name + "/search_alg"), "cusub_cortex/mapper_out/"+task_name)
         self.linkObjectives()
 
-    def initObjectives(self, prior, searchAlg):
-        self.search = Search(searchAlg, prior)
-
-    def initMapperSubs(self):
-        """
-        Just going to the prior so no need to act on any pose estimates
-        """
-        pass
+    def initObjectives(self, prior, searchAlg, topic):
+        self.search = Search(searchAlg, prior, topic)
 
     def linkObjectives(self):
         with self:
             smach.StateMachine.add('Search', self.search, transitions={'aborted':'task_aborted', 'success':'task_success'})
-        


### PR DESCRIPTION
Closes #90. Closes #50 
- Moved all prior and search alg rosparams to be pulled inside the task themselves for a cleaner smach_top.py and more encapsulated task configuration.
- Changed outcomes of search objective to be more intuitive: "found" and 
"not_found"
- Fixed waypoint server access namespacing in smach_top.py and for all 
objectives
- Moved startgate's "dist_behind_gate" param to the config file
- Consolidated method of parsing priors to the task.py Task class